### PR TITLE
removing route53 and updating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,18 @@
+tf_chef_analytics CHANGELOG
+========================
+
+This file is used to list changes made in each version of the tf_chef_analytics Terraform plan.
+
+v0.1.0 (2016-04-13)
+-------------------
+- [Brian Menges] - Reformat [CHANGELOG.md](CHANGELOG.md)
+- [Brian Menges] - Remove Route53 hooks
+- [Brian Menges] - Add `client_version` variable for chef-client version control
+- [Brian Menges] - Add `log_to_file` variable for chef-client runtime logging
+- [Brian Menges] - Documentation updates
+- [Brian Menges] - Add `public_ip` input variable to indicate public IP association to AWS instance
+
 v0.0.1 (2016-03-28)
 -------------------
-- initial commit
+- [Brian Menges] - initial commit
 

--- a/README.md
+++ b/README.md
@@ -50,13 +50,12 @@ These resources will incur charges on your AWS bill. It is your responsibility t
 * `chef_org`: Chef organization to join to
 * `chef_org_validator`: Path to your organization validation PEM
 * `chef_sg`: The Chef server's security group (to allow access to/from Analytics)
+* `client_version`: Chef client version. Default: `12.8.1`
 * `domain`: Server's domain name. Default: `localdomain`
 * `hostname`: Server's hostname. Default: `analytics`
 * `knife_rb`: Path to your knife.rb configuration
-* `r53`: Boolean determines if Route53 will be used or not. Default: `0`
-* `r53_ttl`: Time to Live (TTL) setting for Route53 A record to be created. Default: `180`
-* `r53_zone_id`: AWS Route53 Zone ID to add an A record for the Chef Server
-* `r53_zone_internal_id`: AWS Route53 Internal Zone ID to add an A record for the Chef Server
+* `public_ip`: ssociate public IP to instance. Default `true`
+* `root_delete_termination`: Delete root device on VM termination. Default: `true`
 * `server_count`: Server count. Default: `1`; DO NOT CHANGE!
 * `ssl_cert`: Server SSL certificate in PEM format
 * `ssl_key`: Server SSL certificate key

--- a/variables.tf
+++ b/variables.tf
@@ -121,6 +121,10 @@ variable "chef_org_validator" {
 variable "chef_sg" {
   description = "Chef Server security group id"
 }
+variable "client_version" {
+  description = "Version of the chef-client software to install"
+  default     = "12.8.1"
+}
 variable "domain" {
   description = "Server domain name"
   default     = "localdomain"
@@ -133,21 +137,13 @@ variable "knife_rb" {
   description = "Path to your knife.rb configuration"
   default     = ".chef/knife.rb"
 }
-variable "r53" {
-  description = "Use Route53"
-  default     = 0
+variable "public_ip" {
+  description = "Associate a public IP to the instance"
+  default     = true
 }
-variable "r53_ttl" {
-  description = "Route53 A record TTL (Default: 180)"
-  default     = 180
-}
-variable "r53_zone_id" {
-  description = "Route53 zone id for public DNS"
-  default     = 0
-}
-variable "r53_zone_internal_id" {
-  description = "Route53 zone id for internal DNS"
-  default     = 0
+variable "root_delete_termination" {
+  description = "Delete server root block device on termination"
+  default     = true
 }
 variable "server_count" {
   description = "Number of servers to provision. DO NOT CHANGE!"


### PR DESCRIPTION
- [Brian Menges] - Reformat [CHANGELOG.md](CHANGELOG.md)
- [Brian Menges] - Remove Route53 hooks
- [Brian Menges] - Add `client_version` variable for chef-client version control
- [Brian Menges] - Add `log_to_file` variable for chef-client runtime logging
- [Brian Menges] - Documentation updates
- [Brian Menges] - Add `public_ip` input variable to indicate public IP association to AWS instance
