### PR TITLE
Release v1.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ tf_chef_analytics CHANGELOG
 
 This file is used to list changes made in each version of the tf_chef_analytics Terraform plan.
 
+v1.1.5 (2016-05-02)
+-------------------
+- [Brian Menges] - Cookbook chef-analytics not updated to handle `accept_license` upstream.
+- [Brian Menges] - Revised Chef MLSA acceptance method using existing `null_resource.oc_id-analytics` resource
+
 v1.1.4 (2016-05-02)
 -------------------
 - [Brian Menges] - Remove tags on root_block_device

--- a/main.tf
+++ b/main.tf
@@ -95,6 +95,8 @@ resource "null_resource" "oc_id-analytics" {
     command = <<-EOC
       set +x
       rm -rf .analytics ; mkdir -p .analytics
+			[ ${var.accept_license} -gt 0 ] && touch .analytics/.license.accepted || echo "Chef MLSA not accepted"
+			[ ! -f .analytics/.license.accepted ] && exit 1
       bash ${path.module}/files/chef_api_request GET "/nodes/${var.chef_fqdn}" | jq '.normal' > .analytics/attributes.json.orig
       grep -q 'configuration' .analytics/attributes.json.orig
       [ $? -ne 0 ] && rm -f .analytics/attributes.json.orig && echo "Taking another 30s nap" && sleep 30 && bash ${path.module}/files/chef_api_request GET "/nodes/${var.chef_fqdn}" | jq '.normal' > .analytics/attributes.json.orig


### PR DESCRIPTION
- [Brian Menges] - Cookbook chef-analytics not updated to handle `accept_license` upstream.
- [Brian Menges] - Revised Chef MLSA acceptance method using existing `null_resource.oc_id-analytics` resource
