### PR TITLE
Release v1.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ tf_chef_analytics CHANGELOG
 
 This file is used to list changes made in each version of the tf_chef_analytics Terraform plan.
 
+v1.1.6 (2016-05-02)
+-------------------
+- [Brian Menges] - Terraform variables in `terraform.tfvars` or command-line are strings, not boolean like in `variables.tf` or other plan files
+
 v1.1.5 (2016-05-02)
 -------------------
 - [Brian Menges] - Cookbook chef-analytics not updated to handle `accept_license` upstream.

--- a/main.tf
+++ b/main.tf
@@ -93,9 +93,19 @@ resource "null_resource" "oc_id-analytics" {
   # Generate new attributes file with analytics oc_id subscription
   provisioner "local-exec" {
     command = <<-EOC
-      set +x
       rm -rf .analytics ; mkdir -p .analytics
-			[ ${var.accept_license} -gt 0 ] && touch .analytics/.license.accepted || echo "Chef MLSA not accepted"
+			if [ "${var.accept_license}" == "true" ]
+			then
+			  touch .analytics/.license.accepted
+			elif [ "${var.accept_license}" == "false" ]
+			then
+			  continue
+			elif [ ${var.accept_license} -gt 0 ]
+			then
+			  touch .analytics/.license.accepted
+			else
+			  continue
+			fi
 			[ ! -f .analytics/.license.accepted ] && exit 1
       bash ${path.module}/files/chef_api_request GET "/nodes/${var.chef_fqdn}" | jq '.normal' > .analytics/attributes.json.orig
       grep -q 'configuration' .analytics/attributes.json.orig


### PR DESCRIPTION
- [Brian Menges] - Terraform variables in `terraform.tfvars` or command-line are strings, not boolean like in `variables.tf` or other plan files
